### PR TITLE
Enable linking to emoji-based map URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bootstrap": "4.4.1",
     "emojione": "4.5.0",
-    "geohash-emoji": "1.3.2",
+    "geohash-emoji": "github:bensheldon/geohash-emoji#reverse-it",
     "jquery": "3.5.1",
     "leaflet": "1.7.1",
     "leaflet-geocoder-mapzen": "1.9.4",

--- a/src/scripts/map.js
+++ b/src/scripts/map.js
@@ -18,7 +18,13 @@ var layer = protomaps.leafletLayer({
 })
 layer.addTo(map)
 
-var hash = new L.Hash(map)
+var urlFragment = decodeURIComponent(window.location.hash).replace('#', '');
+if ([...urlFragment].length == 3) {
+  var location = geohash.coordFromHash(urlFragment);
+  map.setView([location[0], location[1]], 12);
+} else {
+  new L.Hash(map)
+}
 
 // Geolocator
 L.control.locate({
@@ -60,8 +66,14 @@ function getEmoji () {
   var lat = center.lat
   var lng = center.lng
   var emoji = geohash.coordAt(lat, lng)
+  window.location.replace("#" + emoji)
   var output = emojione.toImage(emoji)
-  document.getElementById('emojis').innerHTML = output
+
+  var link = document.createElement('a');
+  link.setAttribute('href', '#' + emoji);
+  link.innerHTML = output;
+
+  document.getElementById('emojis').innerHTML = link.outerHTML
   setTitle(emoji)
 }
 


### PR DESCRIPTION
This integrates this PR in emoji-geohash which allows going from emoji -> coordinates: https://github.com/mapmeld/geohash-emoji/pull/7

(once that gets merged and released I won't have to link to my github repo)

Sorry that it looks kind of bad in my local dev environment because the map credentials don't seem to work on localhost, but hopefully it shows the change.

- Preserves existing coordinate-based URLs so that if someone links to that, it will still go to that location
- When dragging the map, the URL hash will be replaced by the 3 emojis
- The 3 emojis in the map pin is now a link (unformatted really, sorry!)
- Visiting the URL with the emojis will load up the location in the map.

![Screenshot 2023-09-21 at 10 05 42 PM](https://github.com/BadIdeaFactory/what3emojis/assets/47554/c77e8183-4507-47f4-a21a-90d759f85c12)

An unfortunate problem is that Chrome _really_ wants to encode the emoji so the URL being copy-pasted looks bad (related to #5; maybe we could put it directly into the clipboard):

http://192.168.7.222:8080/map/#%F0%9F%97%82%F0%9F%94%9B%F0%9F%93%96

Closes #6. Closes #10 
